### PR TITLE
Disable all browser shortcuts

### DIFF
--- a/autokalimba.js
+++ b/autokalimba.js
@@ -455,7 +455,13 @@ window.addEventListener("DOMContentLoaded", (event) => {
   let fifthIndex = -1;
   let keysDown = {};
   document.addEventListener("keydown", (e) => {
-    if (e.repeat) return;
+    // Disable all browser shortcuts. Motivating example: '/' in Firefox
+    // triggers quick-find, as do its repeats, and so does "'", which isn't
+    // even used by autokalimba but is easy to accidentally stumble onto.
+    e.preventDefault();
+    if (e.repeat) {
+      return;
+    }
     if (keysDown[e.key] === true) return;
     keysDown[e.key] = true;
     if (e.key === "Shift") {
@@ -465,7 +471,6 @@ window.addEventListener("DOMContentLoaded", (event) => {
     }
     // if (e.ctrlKey || e.metaKey || e.altKey) return;
     if (e.ctrlKey || e.metaKey || e.altKey) {
-      e.preventDefault();
       return;
     }
 


### PR DESCRIPTION
Motivating example: / triggers quick-find in Firefox.

Done by adding `e.preventDefault()` in every path where a key is recognised, but not in other paths, so that it won't disable bindings that don't conflict.